### PR TITLE
Enable running without root through bwrap

### DIFF
--- a/entrypoint/bash
+++ b/entrypoint/bash
@@ -11,6 +11,6 @@ export HISTFILE="$XDG_STATE_HOME"/bash/history
 
 # Execute bash
 if [ ! -e "$SHELFFILES/result" ]; then
-    exec "$SCRIPT_DIR/launch_in_bwrap.sh" bash "$@"
+    exec "$SCRIPT_DIR/launch_in_bwrap.sh" bash --init-file "$XDG_CONFIG_HOME"/bash/.bashrc "$@"
 fi
 exec bash --init-file "$XDG_CONFIG_HOME"/bash/.bashrc "$@"

--- a/entrypoint/bash
+++ b/entrypoint/bash
@@ -10,4 +10,7 @@ mkdir -p "$XDG_STATE_HOME"/bash
 export HISTFILE="$XDG_STATE_HOME"/bash/history
 
 # Execute bash
+if [ ! -e "$SHELFFILES/result" ]; then
+    exec "$SCRIPT_DIR/launch_in_bwrap.sh" bash "$@"
+fi
 exec bash --init-file "$XDG_CONFIG_HOME"/bash/.bashrc "$@"

--- a/entrypoint/fish
+++ b/entrypoint/fish
@@ -7,4 +7,7 @@ SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
 . "$SCRIPT_DIR/env.sh"
 
 # Execute fish
+if [ ! -e "$SHELFFILES/result" ]; then
+    exec "$SCRIPT_DIR/launch_in_bwrap.sh" fish "$@"
+fi
 exec fish "$@"

--- a/entrypoint/launch_in_bwrap.sh
+++ b/entrypoint/launch_in_bwrap.sh
@@ -2,10 +2,10 @@
 
 set -eu
 
-NIX_STORE_HOST_PATH="${SHELFFILES}/nix/store"
+NIX_HOST_PATH="${SHELFFILES}/nix"
 
-if [ ! -d "$NIX_STORE_HOST_PATH" ]; then
-  echo "Error: Directory not found: ${NIX_STORE_HOST_PATH}" >&2
+if [ ! -d "$NIX_HOST_PATH" ]; then
+  echo "Error: Directory not found: ${NIX_HOST_PATH}" >&2
   exit 1
 fi
 
@@ -47,6 +47,6 @@ done < <(find / -maxdepth 1 -mindepth 1)
 
 # Handle /nix
 BWRAP_ARGS+=(--dir /nix)
-BWRAP_ARGS+=(--bind "$NIX_STORE_HOST_PATH" /nix/store)
+BWRAP_ARGS+=(--bind "$NIX_HOST_PATH" /nix)
 
 exec bwrap "${BWRAP_ARGS[@]}" "$@" 

--- a/entrypoint/launch_in_bwrap.sh
+++ b/entrypoint/launch_in_bwrap.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+set -eu
+
+NIX_STORE_HOST_PATH="${SHELFFILES}/nix/store"
+
+if [ ! -d "$NIX_STORE_HOST_PATH" ]; then
+  echo "Error: Directory not found: ${NIX_STORE_HOST_PATH}" >&2
+  exit 1
+fi
+
+BWRAP_ARGS=(
+  --share-net
+  --proc /proc
+  --dev /dev
+  --tmpfs /tmp
+)
+
+if [ -e /run ]; then
+  BWRAP_ARGS+=(--bind /run /run)
+elif [ ! -h /run ]; then # Create if not exists and not a broken symlink
+  BWRAP_ARGS+=(--dir /run)
+fi
+
+if [ -e /sys ]; then
+  BWRAP_ARGS+=(--ro-bind /sys /sys)
+fi
+
+while IFS= read -r entry_path; do
+  entry_name="$(basename "$entry_path")"
+  case "$entry_name" in
+    proc|dev|tmp|sys|run|nix|lost+found) # Exclude special directories/mount points
+      ;;
+    *)
+      # Check the type of the entry *at the path* (don't follow links for the check)
+      if [ -L "$entry_path" ]; then
+        BWRAP_ARGS+=(--bind "$entry_path" "$entry_path")
+      elif [ -d "$entry_path" ]; then
+        BWRAP_ARGS+=(--bind "$entry_path" "$entry_path")
+      elif [ -f "$entry_path" ]; then
+        # It's a regular file, bind it read-only for safety
+        BWRAP_ARGS+=(--ro-bind "$entry_path" "$entry_path")
+      fi
+      ;;
+  esac
+done < <(find / -maxdepth 1 -mindepth 1)
+
+# Handle /nix
+BWRAP_ARGS+=(--dir /nix)
+BWRAP_ARGS+=(--bind "$NIX_STORE_HOST_PATH" /nix/store)
+
+exec bwrap "${BWRAP_ARGS[@]}" "$@" 

--- a/entrypoint/launch_in_bwrap.sh
+++ b/entrypoint/launch_in_bwrap.sh
@@ -49,4 +49,4 @@ done < <(find / -maxdepth 1 -mindepth 1)
 BWRAP_ARGS+=(--dir /nix)
 BWRAP_ARGS+=(--bind "$NIX_HOST_PATH" /nix)
 
-exec bwrap "${BWRAP_ARGS[@]}" "$@" 
+exec bwrap "${BWRAP_ARGS[@]}" "$@"

--- a/entrypoint/zsh
+++ b/entrypoint/zsh
@@ -15,4 +15,7 @@ export SHELFFILES="$SHELFFILES"
 export USER_ZDOTDIR="$XDG_CONFIG_HOME/zsh"
 
 # Execute zsh
+if [ ! -e "$SHELFFILES/result" ]; then
+    exec "$SCRIPT_DIR/launch_in_bwrap.sh" zsh "$@"
+fi
 exec zsh "$@"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new script to launch commands inside a secure sandbox environment.
  - Bash, Zsh, and Fish shells now automatically run inside a sandbox if certain files are missing, enhancing security and isolation.
- **Chores**
  - Added logic to conditionally determine whether to launch shells directly or within a sandbox based on file presence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->