### PR TITLE
Add install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+set -eu
+
+# Parse arguments
+NO_ROOT=0
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --no-root)
+            NO_ROOT=1
+            shift
+            ;;
+        *)
+            echo "Unknown option: $1"
+            exit 1
+            ;;
+    esac
+done
+
+if [[ "$OSTYPE" == "darwin"* ]] && [ "$NO_ROOT" -eq 1 ]; then
+    echo "Error: --no-root is not supported on macOS"
+    exit 1
+fi
+
+if [ "$NO_ROOT" -eq 0 ]; then
+    if [ -e "$HOME"/.nix-profile/etc/profile.d/nix.sh ]; then
+        # shellcheck disable=SC1091
+        . "$HOME"/.nix-profile/etc/profile.d/nix.sh
+    fi
+    if ! command -v nix &> /dev/null; then
+        echo "Installing Nix..."
+        sh <(curl -L https://nixos.org/nix/install)
+        # shellcheck disable=SC1091
+        . "$HOME"/.nix-profile/etc/profile.d/nix.sh
+    fi
+elif ! command -v nix-portable &> /dev/null; then
+    echo "Installing nix-portable..."
+    curl -L https://github.com/DavHau/nix-portable/releases/download/v012/nix-portable-"$(arch)" -o nix-portable
+    chmod +x nix-portable
+fi
+
+echo "Building..."
+if [ "$NO_ROOT" -eq 0 ]; then
+    nix build --extra-experimental-features nix-command --extra-experimental-features flakes
+else
+    ./nix-portable build --extra-experimental-features nix-command --extra-experimental-features flakes --store "$(pwd)"
+fi

--- a/install.sh
+++ b/install.sh
@@ -33,7 +33,7 @@ if [ "$NO_ROOT" -eq 0 ]; then
         # shellcheck disable=SC1091
         . "$HOME"/.nix-profile/etc/profile.d/nix.sh
     fi
-elif ! command -v nix-portable &> /dev/null; then
+elif [ ! -e nix-portable ]; then
     echo "Installing nix-portable..."
     curl -L https://github.com/DavHau/nix-portable/releases/download/v012/nix-portable-"$(arch)" -o nix-portable
     chmod +x nix-portable
@@ -43,5 +43,5 @@ echo "Building..."
 if [ "$NO_ROOT" -eq 0 ]; then
     nix build --extra-experimental-features nix-command --extra-experimental-features flakes
 else
-    ./nix-portable build --extra-experimental-features nix-command --extra-experimental-features flakes --store "$(pwd)"
+    ./nix-portable nix build --extra-experimental-features nix-command --extra-experimental-features flakes --store "$(pwd)"
 fi


### PR DESCRIPTION
Add helper script to setup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced an installation script that supports both standard and rootless installation modes for Nix.
	- Added support for a `--no-root` option to enable rootless installation (not available on macOS).
	- The script automatically handles dependencies and runs the build process after installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->