### PR TITLE
Support docker run with shelffiles on macOS

### DIFF
--- a/entrypoint/bash
+++ b/entrypoint/bash
@@ -10,7 +10,7 @@ mkdir -p "$XDG_STATE_HOME"/bash
 export HISTFILE="$XDG_STATE_HOME"/bash/history
 
 # Execute bash
-if [ ! -e "$SHELFFILES/result" ]; then
+if [ ! -e "$SHELFFILES/result" ] && [ ! -e "$SHELFFILES/result_docker" ] ; then
     exec "$SCRIPT_DIR/launch_in_bwrap.sh" bash --init-file "$XDG_CONFIG_HOME"/bash/.bashrc "$@"
 fi
 exec bash --init-file "$XDG_CONFIG_HOME"/bash/.bashrc "$@"

--- a/entrypoint/env.sh
+++ b/entrypoint/env.sh
@@ -20,7 +20,7 @@ export XDG_CONFIG_HOME="$SHELFFILES/config"
 export XDG_CACHE_HOME="$SHELFFILES/cache/${PATH_ID}"
 export XDG_DATA_HOME="$SHELFFILES/share/${PATH_ID}"
 export XDG_STATE_HOME="$SHELFFILES/state/${PATH_ID}"
-export PATH="$SHELFFILES/result/bin:$PATH"
+export PATH="$SHELFFILES/result/bin:$SHELFFILES/result_docker/bin:$PATH"
 
 # Create necessary directories
 mkdir -p "$XDG_CACHE_HOME"

--- a/entrypoint/fish
+++ b/entrypoint/fish
@@ -7,7 +7,7 @@ SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
 . "$SCRIPT_DIR/env.sh"
 
 # Execute fish
-if [ ! -e "$SHELFFILES/result" ]; then
+if [ ! -e "$SHELFFILES/result" ] && [ ! -e "$SHELFFILES/result_docker" ] ; then
     exec "$SCRIPT_DIR/launch_in_bwrap.sh" fish "$@"
 fi
 exec fish "$@"

--- a/entrypoint/zsh
+++ b/entrypoint/zsh
@@ -15,7 +15,7 @@ export SHELFFILES="$SHELFFILES"
 export USER_ZDOTDIR="$XDG_CONFIG_HOME/zsh"
 
 # Execute zsh
-if [ ! -e "$SHELFFILES/result" ]; then
+if [ ! -e "$SHELFFILES/result" ] && [ ! -e "$SHELFFILES/result_docker" ] ; then
     exec "$SCRIPT_DIR/launch_in_bwrap.sh" zsh "$@"
 fi
 exec zsh "$@"

--- a/utils/build_nix_in_docker.sh
+++ b/utils/build_nix_in_docker.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+
+docker create --name shelffiles -v "$(pwd):$(pwd)" --workdir "$(pwd)" nixos/nix sleep infinity
+docker start shelffiles
+docker exec shelffiles nix build -o result_docker --extra-experimental-features 'nix-command flakes'
+sudo docker cp shelffiles:/nix "$SCRIPT_DIR"/../


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a script to automate building Nix projects inside a Docker container.

- **Bug Fixes**
  - Improved shell startup behavior by ensuring certain initialization scripts only run if both specific result files are absent.

- **Chores**
  - Updated environment settings to prioritize executables from both result and result_docker directories in the system PATH.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->