### PR TITLE
fix: preserve environment variables in launch_with_nsenter.sh

### DIFF
--- a/entrypoint/launch_with_nsenter.sh
+++ b/entrypoint/launch_with_nsenter.sh
@@ -6,5 +6,5 @@ SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
 
 exec sudo unshare --mount bash -c "
   mount --bind '$SCRIPT_DIR/../nix' /nix
-  exec su -P '$(id -un)' -c '$1'
+  exec su --preserve-environment '$(id -un)' -c '$1'
 "


### PR DESCRIPTION
Replace -P flag with --preserve-environment to ensure all environment variables set by env.sh are inherited by the su command.

Fixes #14

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Replaced the short option with the long option for preserving environment variables when switching users, with no change to functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->