### PR TITLE
Profile directory should be handled by NIX_PROFILES

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -233,8 +233,6 @@ else
     if ! command -v nix &> /dev/null; then
         echo "Installing Nix..."
         sh <(curl -L https://nixos.org/nix/install)
-        # shellcheck disable=SC1091
-        . "$HOME"/.nix-profile/etc/profile.d/nix.sh
     fi
 fi
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Behavior
  - The setup process no longer auto-sources the Nix environment after installation in non-portable setups, so changes won’t apply to the current shell automatically.
- Chores
  - Streamlined setup to avoid implicit environment mutation. Users should open a new shell session or manually source the Nix profile to use Nix immediately after installation. This improves predictability during setup while maintaining the same installed components and outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->